### PR TITLE
basic /bin/blessed.rs working

### DIFF
--- a/src/bin/blessed.rs
+++ b/src/bin/blessed.rs
@@ -1,0 +1,37 @@
+//use crate::lib;
+//use quizface::lib;
+fn main() {
+    println!("bless initiate!");
+    let commands = quizface::ingest_commands();
+    let mut blessed = Vec::new();
+    for command in commands {
+        let command_help_output = quizface::get_command_help(&command);
+        quizface::check_success(&command_help_output.status);
+        let raw_command_help = std::str::from_utf8(&command_help_output.stdout)
+            .expect("Invalid raw_command_help.");
+        let delimiter_test_1: Vec<&str> =
+            raw_command_help.split("Result:\n").collect();
+        let delimiter_test_2: Vec<&str> =
+            raw_command_help.split("Examples:\n").collect();
+        if delimiter_test_1.len() != 1 && delimiter_test_2.len() != 1 {
+            // interesting test would be to put Examples first
+            raw_command_help.split("Result:\n").collect::<Vec<&str>>()[1]
+                .split("Examples:\n")
+                .collect::<Vec<&str>>()[0]
+                // remove leading and trailing whitespace removed,
+                // as defined by Unicode Derived Core Property White_Space
+                .trim();
+            // .is_empty() tests to see if &self has zero bytes
+            if !raw_command_help.is_empty() {
+                blessed.push(command);
+            } else {
+                continue;
+            }
+        } else {
+            continue;
+        }
+    }
+    println!("loop done");
+    println!("{:?}", blessed);
+    println!("Number of blessed commands: {}", blessed.len());
+}

--- a/src/bin/blessed.rs
+++ b/src/bin/blessed.rs
@@ -1,7 +1,6 @@
 //use crate::lib;
 //use quizface::lib;
 fn main() {
-    println!("bless initiate!");
     let commands = quizface::ingest_commands();
     let mut blessed = Vec::new();
     for command in commands {
@@ -15,14 +14,15 @@ fn main() {
             raw_command_help.split("Examples:\n").collect();
         if delimiter_test_1.len() != 1 && delimiter_test_2.len() != 1 {
             // interesting test would be to put Examples first
-            raw_command_help.split("Result:\n").collect::<Vec<&str>>()[1]
-                .split("Examples:\n")
-                .collect::<Vec<&str>>()[0]
-                // remove leading and trailing whitespace removed,
-                // as defined by Unicode Derived Core Property White_Space
-                .trim();
+            let split_command_help =
+                raw_command_help.split("Result:\n").collect::<Vec<&str>>()[1]
+                    .split("Examples:\n")
+                    .collect::<Vec<&str>>()[0]
+                    // remove leading and trailing whitespace removed,
+                    // as defined by Unicode Derived Core Property White_Space
+                    .trim();
             // .is_empty() tests to see if &self has zero bytes
-            if !raw_command_help.is_empty() {
+            if !split_command_help.is_empty() {
                 blessed.push(command);
             } else {
                 continue;
@@ -31,7 +31,6 @@ fn main() {
             continue;
         }
     }
-    println!("loop done");
     println!("{:?}", blessed);
     println!("Number of blessed commands: {}", blessed.len());
 }


### PR DESCRIPTION
Here's a simple,  /bin/blessed.rs with the parent [`d7c4b99f111e553580aa6a0968115cebf0c5d7cc`](url), currently the most recent commit in the [make_parse_help_result_wAnnotator branch](https://github.com/zancas/quizface/tree/make_parse_help_result_wAnnotator). The idea here was to streamline development.

To be blessed a help output would need:
1.   a unique line with Result: as its only token
2.  a unique line with Examples: as its only token
3.  Between Result: and Examples: there's something other than white space

Right now I am simply printing the resulting vec.

Adding the extra `bin/` seems to make it a requirement to specify which module is run with `cargo run`; the main now needs to be run with `cargo run --bin quizface` on my system, and `blessed.rs` with `cargo run --bin blessed`.

I checked visually (manually) against a few examples, and the scheme seems to work. Currently there are 88 blessed commands according to this tool.

I am noticing one issue I will attempt to address with another commit very shortly.