### PR TITLE
new tests based on serde_json::Value

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,6 +287,7 @@ fn make_label(raw_label: &str) -> String {
 
 #[cfg(test)]
 mod unit {
+    use serde_json::json;
     use super::*;
     use crate::utils::test;
 
@@ -457,5 +458,37 @@ mod unit {
     #[test]
     fn parse_raw_output_getblockchaininfo_complete() {
         dbg!(parse_raw_output(test::HELP_GETBLOCKCHAININFO_COMPLETE));
+    }
+
+    #[test]
+    // this is only to test the equivalence of passing in a 
+    // serde_json::Value from test:: to constructing one here
+    fn serde_json_stub() {
+    let bob_import = test::bob_export();
+     // The type of `bob` is `serde_json::Value`
+    let bob = json!({
+        "name": "bob dude",
+        "age": 88,
+        "phones": [
+            "+01 616254827",
+            "+45 746492532",
+            "+01 345835351"
+        ]
+    });
+    assert_eq!(bob, bob_import); 
+    }
+
+    #[test]
+    fn serde_jason_value_help_getinfo() {
+    let getinfo_serde_json_value = test::getinfo_export();
+    let help_getinfo = parse_raw_output(test::HELP_GETINFO);
+    assert_eq!(getinfo_serde_json_value, help_getinfo); 
+    }
+
+    #[test]
+    fn serde_json_value_help_getblockchaininfo() {
+    let getblockchaininfo_serde_json_value = test::getblockchaininfo_export();
+    let help_getblockchaininfo = parse_raw_output(test::HELP_GETBLOCKCHAININFO_COMPLETE);
+    assert_eq!(getblockchaininfo_serde_json_value, help_getblockchaininfo); 
     }
 }

--- a/src/utils/test.rs
+++ b/src/utils/test.rs
@@ -519,3 +519,90 @@ pub fn valid_getinfo_annotation() -> serde_json::Value {
     .map(|(a, b)| (a.to_string(), b.to_string()))
     .collect::<HashMap<String, String>>())
 }
+
+pub fn bob_export() -> serde_json::Value {
+    let bob = serde_json::json!({
+        "name": "bob dude",
+        "age": 88,
+        "phones": [
+            "+01 616254827",
+            "+45 746492532",
+            "+01 345835351"
+        ]
+    });
+    bob
+}
+
+pub fn getinfo_export() -> serde_json::Value {
+    let  getinfo_serde_json_value = serde_json::json!({
+        "version": "Decimal",
+        "protocolversion": "Decimal",
+        "walletversion": "Decimal",
+        "balance": "Decimal",
+        "blocks": "Decimal",
+        "timeoffset": "Decimal",
+        "connections": "Decimal",
+        "proxy": "Option<String>",
+        "difficulty": "Decimal",
+        "testnet": "bool",
+        "keypoololdest": "Decimal",
+        "keypoolsize": "Decimal",
+        "unlocked_until": "Decimal",
+        "paytxfee": "Decimal",
+        "relayfee": "Decimal",
+        "errors": "String",
+    });
+    getinfo_serde_json_value
+}
+pub fn getblockchaininfo_export() -> serde_json::Value {
+    let  getblockchaininfo_serde_json_value = serde_json::json!({
+  "chain": "String",
+  "blocks": "Decimal",
+  "initial_block_download_complete": "bool",
+  "headers": "Decimal",
+  "bestblockhash": "String",
+  "difficulty": "Decimal",
+  "verificationprogress": "Decimal",
+  "estimatedheight": "Decimal",
+  "chainwork": "String",
+  "size_on_disk": "Decimal",
+  "commitments": "Decimal",
+  "softforks": [
+     {
+        "id": "String",
+        "version": "Decimal",
+        "enforce": {
+           "status": "bool",
+           "found": "Decimal",
+           "required": "Decimal",
+           "window": "Decimal"
+        },
+        "reject": { 
+           "status": "bool",
+           "found": "Decimal",
+           "required": "Decimal",
+           "window": "Decimal"
+        },
+     }
+  ],
+  "upgrades": {
+     "String": {
+        "name": "String",
+        "activationheight": "Decimal",
+        "status": "String",
+        "info": "String"
+     }
+  },
+  "consensus": {
+     "chaintip": "String",
+     "nextblock": "String"
+  }
+    });
+    getblockchaininfo_serde_json_value
+}
+// note: softforks had a trailing ... within the array's [ ], possibly
+// to allow for multiple softfork entries. Does this mean there are 
+// potentially unlimited softforks? Is 1 the minimum or could there
+// be 0? would that make it an option?
+// Similar `...` after upgrades, presumably to facilitate multiple upgrade IDs.
+// The leading `"String":` is the upgradeID


### PR DESCRIPTION
a stub and `getinfo` passes, `getblockchaininfo` fails.

We have failing tests!

`test.rs` has some closing comments.

This should be seen as the beginning of testing, the formatting will need adjusting. Nevertheless, this could be potentially seen as a positive step toward test driven development of interpreting some of the other `blessed` commands.
